### PR TITLE
fix: use dashboard as homepage requires acl changes for every restricted page

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -12,32 +12,12 @@ namespace Aviation;
 
 return array(
 
-    'router' => [
-        'routes' => [
-            'lang' => [
-                'options' => [
-                    'defaults' => [
-                        'action' => 'dashboard',
-                    ],
-                ],
-            ],
-        ],
-    ],
     'navigation' => [
         'default' => [
             'dashboard' => [
                 'visible' => false
             ],
         ],
-    ],
-    'acl' => [
-        'rules' => [
-            'recruiter' => [
-                'allow' => [
-                    'route/lang'
-                ]
-            ]
-        ]
     ],
     'service_manager' => [
         'factories' => [

--- a/src/Module.php
+++ b/src/Module.php
@@ -90,6 +90,25 @@ class Module implements VersionProviderInterface
                 $sharedManager->attach($identifier, MvcEvent::EVENT_DISPATCH, $callback, -2 /*postDispatch, but before most of the other zf2 listener*/ );
             }
 
+            $eventManager->attach(
+                MvcEvent::EVENT_ROUTE,
+                function ($event) {
+                    $routeMatch = $event->getRouteMatch();
+
+                    if ($routeMatch->getMatchedRouteName() != 'lang') {
+                        return;
+                    }
+
+                    $router = $event->getRouter();
+                    $url = $router->assemble(['lang' => $routeMatch->getParam('lang')], ['name' => 'lang/dashboard']);
+                    $response = $event->getResponse();
+                    $response->getHeaders()->addHeaderLine('Location', $url);
+                    $response->setStatusCode(302);
+                    return $response;
+                },
+                1
+            );
+
         }
 
     }


### PR DESCRIPTION
To prevent that, the dashboard is now displayed using a browser redirection.
That way no need to alter the acl for guest page access is needed.

[ refs #12 ]
